### PR TITLE
Handle logout scenario if callback is used as the post logout

### DIFF
--- a/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
+++ b/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
@@ -44,8 +44,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import static io.asgardeo.java.oidc.sdk.SSOAgentConstants.IS_LOGOUT;
-
 /**
  * OIDCAgentFilter is the Filter class responsible for building
  * requests and handling responses for authentication, SLO and session
@@ -114,9 +112,8 @@ public class OIDCAgentFilter implements Filter {
                 handleException(request, response, e);
                 return;
             }
-            // Check for logout scenario
-            if (request.getAttribute(IS_LOGOUT) != null && ((boolean)request.getAttribute(IS_LOGOUT))) {
-                request.getSession().invalidate();
+            // Check for logout scenario.
+            if (requestResolver.isLogout()) {
                 response.sendRedirect(oidcAgentConfig.getIndexPage());
                 return;
             }

--- a/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
+++ b/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
@@ -44,6 +44,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import static io.asgardeo.java.oidc.sdk.SSOAgentConstants.IS_LOGOUT;
+
 /**
  * OIDCAgentFilter is the Filter class responsible for building
  * requests and handling responses for authentication, SLO and session
@@ -112,6 +114,12 @@ public class OIDCAgentFilter implements Filter {
                 handleException(request, response, e);
                 return;
             }
+            // Check for logout scenario
+            if (request.getAttribute(IS_LOGOUT) != null && ((boolean)request.getAttribute(IS_LOGOUT))) {
+                request.getSession().invalidate();
+                response.sendRedirect(oidcAgentConfig.getIndexPage());
+                return;
+            }
             response.sendRedirect("home.jsp");
             return;
         }
@@ -168,7 +176,9 @@ public class OIDCAgentFilter implements Filter {
 
     private String buildErrorPageURL(OIDCAgentConfig oidcAgentConfig, HttpServletRequest request) {
 
-        if (StringUtils.isNotBlank(oidcAgentConfig.getIndexPage())) {
+        if (StringUtils.isNotBlank(oidcAgentConfig.getErrorPage())) {
+            return oidcAgentConfig.getErrorPage();
+        } else if (StringUtils.isNotBlank(oidcAgentConfig.getIndexPage())) {
             return oidcAgentConfig.getIndexPage();
         }
         return SSOAgentConstants.DEFAULT_CONTEXT_ROOT;

--- a/io.asgardeo.tomcat.oidc.sample/src/main/webapp/error.jsp
+++ b/io.asgardeo.tomcat.oidc.sample/src/main/webapp/error.jsp
@@ -49,6 +49,11 @@
                     <%=exception.getMessage()%>
                 </h3>
             </div>
+            <form action="index.html" method="post">
+                <div class="element-padding">
+                    <button class="btn primary" type="submit">Back</button>
+                </div>
+            </form>
         </div>
         <img src="images/footer.png" class="footer-image">
     </div>

--- a/io.asgardeo.tomcat.oidc.sample/src/main/webapp/index.html
+++ b/io.asgardeo.tomcat.oidc.sample/src/main/webapp/index.html
@@ -44,7 +44,8 @@
                 </div>
                 <h3>
                     Sample demo to showcase how to authenticate a simple Java application using <br>
-                    <b>Asgardeo</b> with the <a href="https://github.com/asgardeo/asgardeo-tomcat-oidc-agent" target="_blank">Asgardeo OIDC Agent</a>
+                    <b>Asgardeo</b> with the <a href="https://github.com/asgardeo/asgardeo-tomcat-oidc-agent"
+                                                target="_blank">Asgardeo OIDC Agent</a>
                 </h3>
                 <form action="home.jsp" method="post">
                     <div class="element-padding">

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
     </build>
 
     <properties>
-        <io.asgardeo.java.oidc.sdk.version>0.1.8</io.asgardeo.java.oidc.sdk.version>
+        <io.asgardeo.java.oidc.sdk.version>0.1.11</io.asgardeo.java.oidc.sdk.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <xerces.version>2.11.0</xerces.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
     </build>
 
     <properties>
-        <io.asgardeo.java.oidc.sdk.version>0.1.11</io.asgardeo.java.oidc.sdk.version>
+        <io.asgardeo.java.oidc.sdk.version>0.1.12</io.asgardeo.java.oidc.sdk.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <xerces.version>2.11.0</xerces.version>
     </properties>


### PR DESCRIPTION
## Purpose
Previously we had to provide a post-logout URL for the app to work. If not, the callback will be used as the post-logout, and this leads to an error. With this change, we're handling that scenario in the filter and post-logout is not mandatory to provide.

Refers: https://github.com/wso2-enterprise/asgardeo-product/issues/3007
Depends on: https://github.com/asgardeo/asgardeo-java-oidc-sdk/pull/32