### PR TITLE
Change the application type to be used in the Asgardeo console.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Here we are using Asgardeo as the OpenID Provider.
 
 1. Navigate to [**Asgardeo Console**](https://console.asgardeo.io/login) and click on **Applications** under **Develop** tab
    
-2. Click on **New Application** and then **Standard Based Application**.
+2. Click on **New Application** and then **Traditional Web Application**.
    
 3. Select OIDC from the selection and enter any name as the name of the app and add the redirect URL(s).
    
 4. Click on Register. You will be navigated to management page of the created application.
    
-5. Add `https://localhost:8080` (or whichever the URL your app is hosted on) to **Allowed Origins** under **Protocol** tab and check **Public client** option.
+5. Add `https://localhost:8080` (or whichever the URL your app is hosted on) to **Allowed Origins** under **Protocol** tab.
    
 6. Click on **Update** at the bottom.
 


### PR DESCRIPTION
## Purpose
In the README.md file's getting started section, it states that creating a `Standard-Based Application` in the Asgardeo console is required. However, the next few steps are aligned with the `Traditional Web Application` rather than the `Standard-Based Application`. This is a cause of confusion. With this patch the confusion is resolved.

## Approach
Under the  Getting started -> Create an Application in Asgardeo  section,
- Replace the `Standard-Based Application` with `Traditional Web Application` in step 2
- In step 4 remove specifying to enable Public client option. 

It is to be noted that with the updated steps, the sample application works fine.
