### PR TITLE
Fix root path accessing being redirected to an empty page

### DIFF
--- a/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
+++ b/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
@@ -126,6 +126,9 @@ public class OIDCAgentFilter implements Filter {
                 return;
             }
             String homePage = resolveTargetPage(request, requestContext);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Redirection home page is set to " + homePage);
+            }
             response.sendRedirect(homePage);
             return;
         }
@@ -143,20 +146,20 @@ public class OIDCAgentFilter implements Filter {
 
     private String resolveTargetPage(HttpServletRequest request, RequestContext requestContext) {
 
-        String targetPage = "";
         if (StringUtils.isNotBlank(oidcAgentConfig.getHomePage())) {
-            targetPage = oidcAgentConfig.getHomePage();
-        } else if (requestContext != null && StringUtils.isNotBlank((CharSequence) requestContext.getParameter(
+            return oidcAgentConfig.getHomePage();
+        }
+        if (requestContext != null && StringUtils.isNotBlank((CharSequence) requestContext.getParameter(
                 SSOAgentConstants.REDIRECT_URI_KEY))) {
-            targetPage = requestContext.getParameter(SSOAgentConstants.REDIRECT_URI_KEY).toString();
-        } else if (StringUtils.isNotBlank(oidcAgentConfig.getIndexPage())) {
-            targetPage = oidcAgentConfig.getIndexPage();
-        }  else {
-            String requestUrl = request.getRequestURL().toString();
-            targetPage = requestUrl.substring(0, requestUrl.length() - request.getServletPath().length());
+            return requestContext.getParameter(SSOAgentConstants.REDIRECT_URI_KEY).toString();
+        }
+        if (StringUtils.isNotBlank(oidcAgentConfig.getIndexPage())) {
+            return oidcAgentConfig.getIndexPage();
         }
 
-        return targetPage;
+        // If all the checks fail, set root path as the target page.
+        String requestUrl = request.getRequestURL().toString();
+        return requestUrl.substring(0, requestUrl.length() - request.getServletPath().length());
     }
 
     private RequestContext getRequestContext(HttpServletRequest request) {

--- a/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
+++ b/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
@@ -125,10 +125,16 @@ public class OIDCAgentFilter implements Filter {
                 response.sendRedirect(oidcAgentConfig.getIndexPage());
                 return;
             }
+
             String homePage = resolveTargetPage(request, requestContext);
             if (logger.isDebugEnabled()) {
                 logger.debug("Redirection home page is set to " + homePage);
             }
+            if (StringUtils.isBlank(homePage)) {
+                handleException(request, response, new SSOAgentClientException("Redirection target is null."));
+                return;
+            }
+
             response.sendRedirect(homePage);
             return;
         }

--- a/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
+++ b/io.asgardeo.tomcat.oidc.agent/src/main/java/io/asgardeo/tomcat/oidc/agent/OIDCAgentFilter.java
@@ -109,6 +109,11 @@ public class OIDCAgentFilter implements Filter {
 
         if (requestResolver.isCallbackResponse()) {
             RequestContext requestContext = getRequestContext(request);
+            if (requestContext == null) {
+                handleException(request, response, new SSOAgentServerException("Request context is null."));
+                return;
+            }
+
             try {
                 oidcManager.handleOIDCCallback(request, response);
             } catch (SSOAgentException e) {
@@ -120,7 +125,7 @@ public class OIDCAgentFilter implements Filter {
                 response.sendRedirect(oidcAgentConfig.getIndexPage());
                 return;
             }
-            String homePage = resolveTargetPage(requestContext);
+            String homePage = resolveTargetPage(request, requestContext);
             response.sendRedirect(homePage);
             return;
         }
@@ -136,27 +141,32 @@ public class OIDCAgentFilter implements Filter {
         }
     }
 
-    private String resolveTargetPage(RequestContext requestContext) {
+    private String resolveTargetPage(HttpServletRequest request, RequestContext requestContext) {
 
-        String targetPage = "home.jsp";
+        String targetPage = "";
         if (StringUtils.isNotBlank(oidcAgentConfig.getHomePage())) {
             targetPage = oidcAgentConfig.getHomePage();
-        } else if (requestContext != null) {
-            if (requestContext.getParameter(SSOAgentConstants.REDIRECT_URI_KEY) != null) {
-                targetPage = requestContext.getParameter(SSOAgentConstants.REDIRECT_URI_KEY).toString();
-            }
+        } else if (requestContext != null && StringUtils.isNotBlank((CharSequence) requestContext.getParameter(
+                SSOAgentConstants.REDIRECT_URI_KEY))) {
+            targetPage = requestContext.getParameter(SSOAgentConstants.REDIRECT_URI_KEY).toString();
+        } else if (StringUtils.isNotBlank(oidcAgentConfig.getIndexPage())) {
+            targetPage = oidcAgentConfig.getIndexPage();
+        }  else {
+            String requestUrl = request.getRequestURL().toString();
+            targetPage = requestUrl.substring(0, requestUrl.length() - request.getServletPath().length());
         }
+
         return targetPage;
     }
 
-    private RequestContext getRequestContext(HttpServletRequest request) throws SSOAgentServerException {
+    private RequestContext getRequestContext(HttpServletRequest request) {
 
         HttpSession session = request.getSession(false);
 
         if (session != null && session.getAttribute(SSOAgentConstants.REQUEST_CONTEXT) != null) {
             return (RequestContext) request.getSession(false).getAttribute(SSOAgentConstants.REQUEST_CONTEXT);
         }
-        throw new SSOAgentServerException("Request context null.");
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
01)
    If we try to access an application which utilizes the tomcat oidc agent with root path, it gets redirected to an empty page after the authentication. There is a target page resolving logic in which, first the SDK gets the target page from the property file. If it does not configured there, SDK takes the "REDIRECT_URI_KEY". When accessing with root path target page is set as an empty string.
    
    This PR intends to fix it as below.
    - If the home page is defined (`homePage` config), set it as the target page.
    - Else if the `REDIRECT_URI_KEY` is available, set it as the target page.
    - Else if the index page is defined (`indexPage` config), set it as the target page.
    - If that all fails, set root path with absolute url as the target page.

02)
    If we try to access the callback url without authentication, an exception will be thrown. With this PR, it redirects the user to an error page without throwing an exception.

## Related issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/12858
