### PR TITLE
Bump java oidc sdk version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     </build>
 
     <properties>
-        <io.asgardeo.java.oidc.sdk.version>0.1.20</io.asgardeo.java.oidc.sdk.version>
+        <io.asgardeo.java.oidc.sdk.version>0.1.24</io.asgardeo.java.oidc.sdk.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <xerces.version>2.11.0</xerces.version>
     </properties>


### PR DESCRIPTION
## Description
Bump Java OIDC SDK version 0.1.24.

## Related issue
- https://github.com/wso2-enterprise/asgardeo-product/issues/18105